### PR TITLE
Use new Digest::SHA module instead of old Digest::SHA1

### DIFF
--- a/bin/send-hassles
+++ b/bin/send-hassles
@@ -15,7 +15,7 @@ use lib "$FindBin::Bin/../commonlib/perllib";
 
 use DBI;
 use DBD::Pg;
-use Digest::SHA1 qw(sha1_hex);
+use Digest::SHA qw(sha1_hex);
 use IO::Pipe;
 use Getopt::Long;
 

--- a/perllib/Hassle.pm
+++ b/perllib/Hassle.pm
@@ -11,7 +11,7 @@ package Hassle;
 
 use DBI;
 use DBD::Pg;
-use Digest::SHA1 qw(sha1_hex);
+use Digest::SHA qw(sha1_hex);
 use IO::Pipe;
 use MIME::QuotedPrint;
 use mySociety::Email;


### PR DESCRIPTION
There are no functional changes to using the new module when using SHA1,
but only the new name is available on Debian wheezy.
