### PR TITLE
Don't indent email text

### DIFF
--- a/perllib/Hassle.pm
+++ b/perllib/Hassle.pm
@@ -121,6 +121,7 @@ EOF
 
     my $mail = mySociety::Email::construct_email({
         _unwrapped_body_ => $text,
+        _line_indent => '',
         From => ['hassle@hassleme.co.uk', 'HassleBot'],
         Subject => $subject,
         To => $to,


### PR DESCRIPTION
This change has brought milo's MSN reputation from red to yellow, so I think it's worth keeping.
